### PR TITLE
Add info on adding homebridge user to sound group (arecord no soundcards found...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,15 +76,15 @@ The default values work with my First Alert smoke alarms and many other alarms i
 
 If you're having trouble getting your microphone device to detect in your linux environment, eg:
 
-```shell
-$ sudo aplay -l  
+```bash
+$ sudo arecord -l  
 aplay: device_list:240: no soundcards found...
 ```
 
 Ensure that you [add your `homebridge` user to the `audio` group](https://askubuntu.com/questions/57810/how-to-fix-no-soundcards-found).
 
 ```shell
-sudo adduser homebridge audio
+$ sudo adduser homebridge audio
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,24 @@ The default values work with my First Alert smoke alarms and many other alarms i
 
 - Can be spoofed with a sufficiently loud recording of the alarm. Don't do anything goofy like use it to unlock doors, etc.
 
+## FAQs
+
+### Add user to `sound` group
+
+If you're having trouble getting your microphone device to detect in your linux environment, eg:
+
+```shell
+$ sudo aplay -l  
+aplay: device_list:240: no soundcards found...
+```
+
+Ensure that you [add your `homebridge` user to the `audio` group](https://askubuntu.com/questions/57810/how-to-fix-no-soundcards-found).
+
+```shell
+sudo adduser homebridge audio
+```
+
+
 ## Disclaimer
 
 This is a hobby project, and is not intended to be used in any life-critical systems. This software comes without any guarantees of any kind, so don't come after me if it malfunctions and bad things happen. 


### PR DESCRIPTION
I ran into an issue with my homebridge instance not able to detect my AmazonBasics microphone that I had plugged in via USB, with the error

```
$ sudo arecord -l   (or sudo aplay -l)
aplay: device_list:240: no soundcards found...
```

I am running my homebridge as a VM in proxmox, so I had originally thought the USB passthrough was the issue, but turns out simply needed to add my homebridge user to the `audio` group. 

Adding that info in the readme for the next guy