### PR TITLE
Added name property to config-schema

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -5,6 +5,13 @@
   "schema": {
     "type": "object",
     "properties": {
+      "name": {
+        "title": "Listener Name",
+        "type": "string",
+        "default": "Smoke Alarm",
+        "minLength": 1,
+        "required": true
+      },
       "frequency": {
         "title": "Alarm Frequency",
         "type": "integer",


### PR DESCRIPTION
Add new required property to config-schema for config-ui-x users to easily specify the name of the alarm/smoke detector